### PR TITLE
Add hooks to handle CR order

### DIFF
--- a/tooling/charts/do500/templates/crw/crd-reader.yaml
+++ b/tooling/charts/do500/templates/crw/crd-reader.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.crw }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crd-reader
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - 'customresourcedefinitions'
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crd-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-reader
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: do500
+{{- end -}}
+

--- a/tooling/charts/do500/templates/crw/crw.yaml
+++ b/tooling/charts/do500/templates/crw/crw.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Values.crw.name | default "codeready-workspaces" | quote }}
   namespace: {{ .Values.crw.namespace | default "do500-workspaces" | quote }}
 spec:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": hook-failed
   server:
     cheImageTag: {{ .Values.crw.cheImageTag | default "" | quote }}
     cheFlavor: {{ .Values.crw.cheFlavor | default "codeready" | quote }}

--- a/tooling/charts/do500/templates/crw/wait-for-crd.yaml
+++ b/tooling/charts/do500/templates/crw/wait-for-crd.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.crw }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: che-cluster-check 
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-weight": "-10"
+spec:
+  containers:
+  - name: crd-check 
+    image: quay.io/openshift/origin-cli:4.6
+    imagePullPolicy: IfNotPresent
+    command: ['sh', '-c', 'while [ true ]; do oc get crd checlusters.org.eclipse.che; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0
+{{- end -}}
+                     


### PR DESCRIPTION
Resolves #10 

@jacobsee @haithamshahin333 @jtudelag This looks to fix the issue we have with the CR for CodeReady being installed before the CRD's are ready. Not a glamerous solution, but it works. Might be something we want to come back to and discuss if there's a better layout in the future.

Leaving this as a draft as I'd like a few other folks to give this a shot and see it working as expected. I tested this on CRC and everything appeared to work well. But want to see this work for others before we merge it in.