### PR TITLE
🦆 WIP - Subscriptions only argument 🦆

### DIFF
--- a/tooling/README.md
+++ b/tooling/README.md
@@ -10,15 +10,25 @@ This chart is capable of deploying the following:
 
 ## Installation
 
-The following needs to be run by someone who is an admin in your OpenShift cluster.
+The following needs to be run by someone who is an admin in your OpenShift cluster from within the chart directory.
 
-To install this chart, you can run the following from within the chart directory:
+On a new cluster, no CRD's exist so to avoid this, we install the operator subscriptions first as its own release:
+```bash
+helm install do500-operator tooling/charts/do500 --namespace do500 --set subscriptions.only=true
+```
 
-`helm install do500 . --create-namespace --namespace do500`
+This will spin up the CRW workspace operator in the `do500-workspaces` project.
+
+To install the rest of the applications, you can run the following:
+```bash
+helm install do500 tooling/charts/do500 --namespace do500
+```
 
 To uninstall, you can just do the reverse:
-
-`helm uninstall do500 --namespace do500`
+```bash
+helm uninstall do500 --namespace do500
+helm uninstall do500-operator --namespace do500
+```
 
 ## Gitlab
 

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -47,7 +47,7 @@ helm upgrade --install do500 tooling/charts/do500 --namespace do500
 
 ## Gitlab
 
-With Gitlab, it expects to be able to run against a configured LDAP server. This can be acheived by either uncommenting and providing the appropriate values in your `values.yaml` or you can allow the helm chart to discover these values itself.
+With Gitlab, it expects to be able to run against a configured LDAP server. This can be achieved by either uncommenting and providing the appropriate values in your `values.yaml` or you can allow the helm chart to discover these values itself.
 
 **Note**: There is currently a bug where the chart only looks at the first configured IdentityProvider within the default `OAuth` configuration of the OpenShift cluster to check for an ldap configuration. This is being tracked <here>. In the mean time, you can change it to look at the appropriate position by changing the following occurrences of:
 
@@ -65,5 +65,4 @@ After this is deployed, you will have a functional gitlab server that can be use
 
 ## CodeReady Workspaces
 
-With CRW, this uses the provided Operator to deploy a CRW instance. With the provided defaults, it restricts uses to two workspaces and allows for only a single `running` instance.
-
+With CRW, this uses the provided Operator to deploy a CRW instance. With the provided defaults, it restricts users to deploying two workspaces only and allows for a single `running` instance per user.

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -30,6 +30,21 @@ helm uninstall do500 --namespace do500
 helm uninstall do500-operator --namespace do500
 ```
 
+## Updating charts
+
+Your deployments should look something like this:
+```bash
+$ helm list -n do500
+NAME          	NAMESPACE	REVISION	UPDATED                                 	STATUS  	CHART          	APP VERSION
+do500         	do500    	1       	2021-01-26 16:46:20.477010119 +1000 AEST	deployed	do500-env-0.0.1	0.0.1      
+do500-operator	do500    	1       	2021-01-26 16:40:56.886855854 +1000 AEST	deployed	do500-env-0.0.1	0.0.1 
+```
+
+If you change anything in `values.yaml` run upgrade install to update the release
+```bash
+helm upgrade --install do500 tooling/charts/do500 --namespace do500
+```
+
 ## Gitlab
 
 With Gitlab, it expects to be able to run against a configured LDAP server. This can be acheived by either uncommenting and providing the appropriate values in your `values.yaml` or you can allow the helm chart to discover these values itself.

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -30,7 +30,7 @@ helm uninstall do500 --namespace do500
 helm uninstall do500-operator --namespace do500
 ```
 
-## Updating charts
+## Updating
 
 Your deployments should look something like this:
 ```bash

--- a/tooling/charts/do500/templates/crw/crw.yaml
+++ b/tooling/charts/do500/templates/crw/crw.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crw }}
+{{- if and .Values.crw (not .Values.subscriptions.only) }}
 apiVersion: org.eclipse.che/v1
 kind: CheCluster
 metadata:

--- a/tooling/charts/do500/templates/docs/build.yaml
+++ b/tooling/charts/do500/templates/docs/build.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.docs }}
+{{- if and .Values.docs (not .Values.subscriptions.only) }}
 ---
 kind: BuildConfig
 apiVersion: build.openshift.io/v1

--- a/tooling/charts/do500/templates/docs/deploy.yaml
+++ b/tooling/charts/do500/templates/docs/deploy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.docs }}
+{{- if and .Values.docs (not .Values.subscriptions.only) }}
 ---
 apiVersion: v1
 kind: DeploymentConfig

--- a/tooling/charts/do500/templates/docs/imagestream.yaml
+++ b/tooling/charts/do500/templates/docs/imagestream.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.docs }}
+{{- if and .Values.docs (not .Values.subscriptions.only) }}
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream

--- a/tooling/charts/do500/templates/docs/routes.yaml
+++ b/tooling/charts/do500/templates/docs/routes.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.docs }}
+{{- if and .Values.docs (not .Values.subscriptions.only) }}
 kind: Route
 apiVersion: v1
 metadata:

--- a/tooling/charts/do500/templates/docs/service.yaml
+++ b/tooling/charts/do500/templates/docs/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.docs }}
+{{- if and .Values.docs (not .Values.subscriptions.only) }}
 ---
 kind: Service
 apiVersion: v1

--- a/tooling/charts/do500/templates/gitlab/anyuid-scc.yaml
+++ b/tooling/charts/do500/templates/gitlab/anyuid-scc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gitlab }}
+{{- if and .Values.gitlab (not .Values.subscriptions.only) }}
 kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 allowHostDirVolumePlugin: false

--- a/tooling/charts/do500/templates/gitlab/deployments.yaml
+++ b/tooling/charts/do500/templates/gitlab/deployments.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gitlab -}}
+{{- if and .Values.gitlab (not .Values.subscriptions.only) -}}
 {{ $db_user := include "gitlab.postgres.user" . }}
 {{ $db_pass := include "gitlab.postgres.password" . }}
 {{ $db_admin_pass := include "gitlab.postgres.admin_password" . }}

--- a/tooling/charts/do500/templates/gitlab/imagestreams.yaml
+++ b/tooling/charts/do500/templates/gitlab/imagestreams.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gitlab -}}
+{{- if and .Values.gitlab (not .Values.subscriptions.only) -}}
 {{- range $is := .Values.gitlab.imagestreams }}
 ---
 kind: ImageStream

--- a/tooling/charts/do500/templates/gitlab/routes.yaml
+++ b/tooling/charts/do500/templates/gitlab/routes.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gitlab }}
+{{- if and .Values.gitlab (not .Values.subscriptions.only) }}
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:

--- a/tooling/charts/do500/templates/gitlab/serviceaccounts.yaml
+++ b/tooling/charts/do500/templates/gitlab/serviceaccounts.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gitlab }}
+{{- if and .Values.gitlab (not .Values.subscriptions.only) }}
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/tooling/charts/do500/templates/gitlab/services.yaml
+++ b/tooling/charts/do500/templates/gitlab/services.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gitlab }}
+{{- if and .Values.gitlab (not .Values.subscriptions.only) }}
 ---
 kind: Service
 apiVersion: v1

--- a/tooling/charts/do500/templates/gitlab/volumeclaims.yaml
+++ b/tooling/charts/do500/templates/gitlab/volumeclaims.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gitlab }}
+{{- if and .Values.gitlab (not .Values.subscriptions.only) }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tooling/charts/do500/templates/namespace.yaml
+++ b/tooling/charts/do500/templates/namespace.yaml
@@ -1,7 +1,9 @@
+{{- if .Values.subscriptions.only }}
 {{- range $key := .Values.namespaces }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: "{{ $.Values.prefix }}{{- if ne $.Values.prefix "" }}-{{- else }}{{ end }}{{ .name }}"
+{{- end }}
 {{- end }}

--- a/tooling/charts/do500/templates/operators/operatorgroup.yaml
+++ b/tooling/charts/do500/templates/operators/operatorgroup.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.subscriptions.only }}
 {{- range $op := .Values.operators }}
 {{- if $op.operatorgroup }}
 {{- $og := $op.operatorgroup }}
@@ -10,5 +11,6 @@ metadata:
 spec:
   targetNamespaces:
   - {{ $op.namespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/tooling/charts/do500/templates/operators/subscription.yaml
+++ b/tooling/charts/do500/templates/operators/subscription.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.subscriptions.only }}
 {{- range $op := .Values.operators }}
 {{- $sub := $op.subscription }}
 ---
@@ -14,6 +15,7 @@ spec:
   sourceNamespace: {{ $sub.sourceNamespace | default "openshift-marketplace" | quote }}
 {{- if $sub.csv }}
   startingCSV: {{ $sub.csv }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/tooling/charts/do500/values.yaml
+++ b/tooling/charts/do500/values.yaml
@@ -12,6 +12,10 @@ namespaces:
   - name: do500-gitlab
 #  - name: do500-slides
 
+# subscriptions
+subscriptions:
+  only: false
+
 operators:
   - name: codeready-workspaces
     namespace: do500-workspaces
@@ -21,13 +25,13 @@ operators:
       operatorName: codeready-workspaces
       sourceName: redhat-operators
       sourceNamespace: openshift-marketplace
-      csv: crwoperator.v2.5.0
+      csv: crwoperator.v2.5.1
     operatorgroup:
       create: true
 
 gitlab:
   namespace: do500-gitlab
-  root_password: Password123
+  root_password: password
   imagestreams:
     - name: "gitlab-ce"
       tag_name: "gitlab-12.8.7"
@@ -44,7 +48,7 @@ gitlab:
 #    uri: "MY-LDAP.example.corp.com"
 #    user_filter: ""
 #    validate_certs: "false"
-    secret_name: my-ldap-secret-name
+    secret_name: ldap-bind-password
 #    bind_dn: uid=ldap-admin,cn=users,cn=accounts,dc=CORP,dc=EXAMPLE,dc=COM
 
 crw:


### PR DESCRIPTION
allow deployment of helm chart to new cluster where no crd's exist, to avoid this error:

```
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "CheCluster" in version "org.eclipse.che/v1"
```

changed instructions .. two step process - deploy subscriptions (and namespaces) then CR's and apps.

uses the same chart for both.
