### PR TITLE
Updates for Openshift >= 4.6

### DIFF
--- a/tooling/charts/do500/templates/docs/deploy.yaml
+++ b/tooling/charts/do500/templates/docs/deploy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.docs }}
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   name: "{{ .Values.docs.name }}"

--- a/tooling/charts/do500/templates/docs/routes.yaml
+++ b/tooling/charts/do500/templates/docs/routes.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.docs }}
 kind: Route
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 metadata:
   name: "{{ .Values.docs.name }}"
   namespace: "{{ .Values.docs.namespace }}"

--- a/tooling/charts/do500/templates/gitlab/anyuid-scc.yaml
+++ b/tooling/charts/do500/templates/gitlab/anyuid-scc.yaml
@@ -1,41 +1,14 @@
 {{- if .Values.gitlab }}
-kind: SecurityContextConstraints
-apiVersion: security.openshift.io/v1
-allowHostDirVolumePlugin: false
-allowHostIPC: false
-allowHostNetwork: false
-allowHostPID: false
-allowHostPorts: false
-allowPrivilegeEscalation: true
-allowPrivilegedContainer: false
-allowedCapabilities: null
-defaultAddCapabilities: null
-fsGroup:
-  type: RunAsAny
-groups:
-- system:cluster-admins
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  annotations:
-    kubernetes.io/description: anyuid provides all features of the restricted SCC
-      but allows users to run with any UID and any GID.
-  name: "{{ .Values.gitlab_app_name }}-anyuid"
-priority: 10
-readOnlyRootFilesystem: false
-requiredDropCapabilities:
-- MKNOD
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: MustRunAs
-supplementalGroups:
-  type: RunAsAny
-users:
-- system:serviceaccount:{{ .Values.gitlab.namespace }}:{{ .Values.gitlab_app_name }}-user
-volumes:
-- configMap
-- downwardAPI
-- emptyDir
-- persistentVolumeClaim
-- projected
-- secret
+  name: system:openshift:scc:anyuid
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.gitlab_app_name }}-user
+  namespace: {{ .Values.gitlab.namespace }}
 {{- end }}

--- a/tooling/charts/do500/templates/gitlab/routes.yaml
+++ b/tooling/charts/do500/templates/gitlab/routes.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: "{{ $.Values.gitlab_app_name }}"
 spec:
-  host: "{{ $.Values.gitlab_app_name }}.{{ include "do500.app_domain" . }}"
+  host: {{ $.Values.gitlab_app_name }}.{{ include "do500.app_domain" . }}
   to:
     kind: Service
     name: "{{ $.Values.gitlab_app_name }}"


### PR DESCRIPTION
Just a couple of things to note in the PR:

- Updated apiVersion to use fully qualified path
- Uses a `ClusterRoleBinding` for gitlab-user to use the `system:openshift:scc:anyuid` role rather than creating a new system SCC which is inline with updated training and how the newest `oc adm policy add-scc-to-user ...` is doing things
- Hostname in the gitlab route has two sets of  double quotes which doesn't play well with linters and syntax highlighting.