### PR TITLE
Temporary workaround to deploy nicely via LodeStar

### DIFF
--- a/helm-release.yml
+++ b/helm-release.yml
@@ -6,6 +6,6 @@ metadata:
 spec:
   releaseName: do500 
   chart:
-    git: https://github.com/tylerauerbeck/enablement-framework
-    ref: helm-operator
+    git: https://github.com/rht-labs/enablement-framework
+    ref: main
     path: tooling/charts/do500 

--- a/helm-release.yml
+++ b/helm-release.yml
@@ -1,0 +1,11 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: enablement-framework 
+  namespace: do500
+spec:
+  releaseName: do500 
+  chart:
+    git: https://github.com/tylerauerbeck/enablement-framework
+    ref: helm-operator
+    path: tooling/charts/do500 


### PR DESCRIPTION
This adds a HelmChart CR (to work with the Helm Operator) which is a (very) temporary workaround in order to get this to deploy nicely via the applier via LodeStar.