### PR TITLE
🫑  add stackrox 🫑

### DIFF
--- a/codereadyworkspaces/do500-devfile.yaml
+++ b/codereadyworkspaces/do500-devfile.yaml
@@ -25,7 +25,7 @@ components:
     id: redhat/vscode-yaml/latest
   - type: dockerimage
     alias: stack-do500
-    image: quay.io/rht-labs/stack-do500:3.0.5
+    image: quay.io/rht-labs/stack-do500:3.0.6
     memoryLimit: 2Gi
     mountSources: true
     command: ['/bin/sh', '-c', 'sleep infinity']

--- a/codereadyworkspaces/stack/Dockerfile
+++ b/codereadyworkspaces/stack/Dockerfile
@@ -18,7 +18,8 @@ ENV ARGOCD_VERSION=2.0.5 \
     JQ_VERSION=1.6 \
     CONFTEST_VERSION=0.23.0 \
     ZSH_VERSION=5.8 \
-    ROX_VERSION=3.63.0
+    ROX_VERSION=3.63.0 \
+    KUBELINTER_VERSION=0.2.2
 
 # this is based off of registry.redhat.io/codeready-workspaces/plugin-java8-rhel8
 ENV NODEJS_VERSION=14 \
@@ -66,6 +67,11 @@ RUN rm -f /usr/bin/oc && \
 RUN curl -sL -o /usr/local/bin/roxctl https://mirror.openshift.com/pub/rhacs/assets/${ROX_VERSION}/bin/Linux/roxctl && \
     chmod +x /usr/local/bin/roxctl && \
     echo "🦜🦜🦜🦜🦜"
+
+# kube-linter
+RUN curl -sL https://github.com/stackrox/kube-linter/releases/download/${KUBELINTER_VERSION}/kube-linter-linux.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chmod +x /usr/local/bin/kube-linter && \
+    echo "🐐🐐🐐🐐🐐"
 
 # jq / yq
 RUN curl -sLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && \

--- a/codereadyworkspaces/stack/VERSION
+++ b/codereadyworkspaces/stack/VERSION
@@ -1,2 +1,2 @@
-VERSION=3.0.5
+VERSION=3.0.6
 

--- a/tooling/charts/do500/Chart.yaml
+++ b/tooling/charts/do500/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: do500
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.0.1
 maintainers:
   - name: eformat

--- a/tooling/charts/do500/templates/crd-reader.yaml
+++ b/tooling/charts/do500/templates/crd-reader.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -23,7 +23,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tooling/charts/do500/templates/operators/operatorgroup.yaml
+++ b/tooling/charts/do500/templates/operators/operatorgroup.yaml
@@ -1,5 +1,5 @@
 {{- range $op := .Values.operators }}
-{{- if $op.operatorgroup }}
+{{- if $op.operatorgroup.create }}
 {{- $og := $op.operatorgroup }}
 ---
 apiVersion: operators.coreos.com/v1

--- a/tooling/charts/do500/templates/stackrox/central.yaml
+++ b/tooling/charts/do500/templates/stackrox/central.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.stackrox.enabled }}
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "25"
+  namespace: openshift-operators
+  name: stackrox-central-services
+spec:
+  central:
+    exposure:
+      loadBalancer:
+        enabled: false
+        port: 443
+      nodePort:
+        enabled: false
+      route:
+        enabled: true
+    persistence:
+      persistentVolumeClaim:
+        claimName: stackrox-db
+  egress:
+    connectivityPolicy: Online
+  scanner:
+    analyzer:
+      scaling:
+        autoScaling: Enabled
+        maxReplicas: 5
+        minReplicas: 2
+        replicas: 3
+    scannerComponent: Enabled
+{{- end }}

--- a/tooling/charts/do500/templates/stackrox/central.yaml
+++ b/tooling/charts/do500/templates/stackrox/central.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "25"
-  namespace: openshift-operators
+  namespace: stackrox
   name: stackrox-central-services
 spec:
   central:

--- a/tooling/charts/do500/templates/stackrox/namespace.yaml
+++ b/tooling/charts/do500/templates/stackrox/namespace.yaml
@@ -3,5 +3,4 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: {{ .Values.stackrox.namespace | quote }}
-EOF
 {{- end }}

--- a/tooling/charts/do500/templates/stackrox/namespace.yaml
+++ b/tooling/charts/do500/templates/stackrox/namespace.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.stackrox.enabled }}
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: {{ .Values.stackrox.namespace | quote }}
+EOF
+{{- end }}

--- a/tooling/charts/do500/templates/stackrox/secured-cluster.yaml
+++ b/tooling/charts/do500/templates/stackrox/secured-cluster.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.stackrox.enabled }}
+apiVersion: platform.stackrox.io/v1alpha1
+kind: SecuredCluster
+metadata:
+  name: stackrox-secured-cluster-services
+  namespace: {{ .Values.stackrox.namespace | quote }}
+spec:
+  admissionControl:
+    listenOnCreates: false
+    listenOnEvents: true
+    listenOnUpdates: false
+  auditLogs:
+    collection: Auto
+  centralEndpoint: 'central.stackrox:443'
+  clusterName: {{ .Values.stackrox.clusterName | quote }}
+  perNode:
+    collector:
+      collection: KernelModule
+      imageFlavor: Regular
+    taintToleration: TolerateTaints
+{{- end }}

--- a/tooling/charts/do500/templates/stackrox/secured-cluster.yaml
+++ b/tooling/charts/do500/templates/stackrox/secured-cluster.yaml
@@ -4,6 +4,9 @@ kind: SecuredCluster
 metadata:
   name: stackrox-secured-cluster-services
   namespace: {{ .Values.stackrox.namespace | quote }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "25"
 spec:
   admissionControl:
     listenOnCreates: false

--- a/tooling/charts/do500/templates/wait-for-crd.yaml
+++ b/tooling/charts/do500/templates/wait-for-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
   - name: crd-check

--- a/tooling/charts/do500/values.yaml
+++ b/tooling/charts/do500/values.yaml
@@ -35,6 +35,18 @@ operators:
     operatorgroup:
       create: false
 
+  - name: rhacs-operator
+    namespace: openshift-operators
+    subscription:
+      channel: latest
+      approval: Automatic
+      operatorName: rhacs-operator
+      source: redhat-operators
+      sourceNamespace: openshift-marketplace
+      startingCSV: rhacs-operator.v3.63.0
+    operatorgroup:
+      create: false
+
 gitlab:
   namespace: do500-gitlab
   root_password: Password123
@@ -94,3 +106,8 @@ sealed-secrets:
     - "--update-status=true"
 
 userworkloadmonitoring: true
+
+stackrox:
+  enabled: true
+  clusterName: do500
+  namespace: stackrox


### PR DESCRIPTION
add stackrox/ACS operator and installation

installs operator, central and secured cluster.

does NOT currently wire up the init bundle in stackrox, cause there is a chicken and egg with generating the api token needed. so left that for now.