### PR TITLE
🐟 logging install fix ups 🐟

### DIFF
--- a/tooling/README.md
+++ b/tooling/README.md
@@ -9,6 +9,9 @@ This chart is capable of deploying the following:
 - Instructor Documentation
 - SealedSecrets from Bitnami
 - OpenShift Pipelines
+- Advanced Cluster Security (StackRox)
+- Cluster Logging (ELK)
+- Certificate Utils
 
 ## Installation
 

--- a/tooling/charts/do500/templates/crw/crw.yaml
+++ b/tooling/charts/do500/templates/crw/crw.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "25"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   name: {{ .Values.crw.name | default "codeready-workspaces" | quote }}
   namespace: {{ .Values.crw.namespace | default "do500-workspaces" | quote }}
 spec:

--- a/tooling/charts/do500/templates/crw/crw.yaml
+++ b/tooling/charts/do500/templates/crw/crw.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "25"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   name: {{ .Values.crw.name | default "codeready-workspaces" | quote }}
   namespace: {{ .Values.crw.namespace | default "do500-workspaces" | quote }}
 spec:

--- a/tooling/charts/do500/templates/logging/clusterlogging.yaml
+++ b/tooling/charts/do500/templates/logging/clusterlogging.yaml
@@ -4,6 +4,10 @@ kind: ClusterLogging
 metadata:
   name: instance
   namespace: openshift-logging
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   collection:
     logs:

--- a/tooling/charts/do500/templates/logging/clusterlogging.yaml
+++ b/tooling/charts/do500/templates/logging/clusterlogging.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "25"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   collection:
     logs:

--- a/tooling/charts/do500/templates/logging/namespace.yaml
+++ b/tooling/charts/do500/templates/logging/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: openshift-logging

--- a/tooling/charts/do500/templates/logging/namespace.yaml
+++ b/tooling/charts/do500/templates/logging/namespace.yaml
@@ -3,3 +3,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
  name: openshift-logging
+ labels:
+   openshift.io/cluster-monitoring: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: openshift-operators-redhat
+ labels:
+   openshift.io/cluster-monitoring: "true"

--- a/tooling/charts/do500/templates/wait-for-crd.yaml
+++ b/tooling/charts/do500/templates/wait-for-crd.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   containers:
   - name: crd-check
-    image: quay.io/openshift/origin-cli:4.6
+    image: quay.io/openshift/origin-cli:4.8
     imagePullPolicy: IfNotPresent
-    command: ['sh', '-c', 'while [ true ]; do oc get crd checlusters.org.eclipse.che; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
+    command: ['sh', '-c', 'while [ true ]; do oc get crd checlusters.org.eclipse.che centrals.platform.stackrox.io; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
   restartPolicy: Never
   terminationGracePeriodSeconds: 0
   serviceAccount: default

--- a/tooling/charts/do500/values.yaml
+++ b/tooling/charts/do500/values.yaml
@@ -60,10 +60,11 @@ operators:
       create: false
 
   - name: elasticsearch-operator
-    namespace: openshift-operators-redhat
+    namespace: openshift-operators
     subscription:
       channel: stable-5.1
       approval: Automatic
+      operatorName: elasticsearch-operator
       source: redhat-operators
       sourceNamespace: openshift-marketplace
       startingCSV: elasticsearch-operator.5.1.1-36
@@ -80,7 +81,7 @@ operators:
       sourceNamespace: openshift-marketplace
       startingCSV: cluster-logging.5.1.1-36
     operatorgroup:
-      create: false
+      create: true
 
 logging:
   # Might be needed with clusters that have an infra plane
@@ -95,8 +96,8 @@ logging:
 
   elasticsearch:
     requests:
-      cpu: 500m
-      memory: 4Gi
+      cpu: 250m
+      memory: 512Mi
     limits:
       cpu: 4000m
       memory: 16Gi
@@ -131,7 +132,7 @@ gitlab:
 #    validate_certs: "false"
 #    bind_dn: uid=ldap-admin,cn=users,cn=accounts,dc=CORP,dc=EXAMPLE,dc=COM
 #    password: password
-    secret_name: my-ldap-secret-name
+    secret_name: ldap-bind-password
 
 crw:
   namespace: do500-workspaces

--- a/tooling/charts/do500/values.yaml
+++ b/tooling/charts/do500/values.yaml
@@ -31,7 +31,7 @@ operators:
       operatorName: openshift-pipelines-operator-rh
       sourceName: redhat-operators
       sourceNamespace: openshift-marketplace
-      csv: redhat-openshift-pipelines.v1.5.0
+      csv: redhat-openshift-pipelines.v1.5.1
     operatorgroup:
       create: false
 
@@ -43,7 +43,7 @@ operators:
       operatorName: cert-utils-operator
       sourceName: community-operators
       sourceNamespace: openshift-marketplace
-      csv: cert-utils-operator.v1.1.0
+      csv: cert-utils-operator.v1.3.0
     operatorgroup:
       create: false
 
@@ -55,7 +55,7 @@ operators:
       operatorName: rhacs-operator
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: rhacs-operator.v3.63.0
+      startingCSV: rhacs-operator.v3.64.1
     operatorgroup:
       create: false
 

--- a/tooling/charts/do500/values.yaml
+++ b/tooling/charts/do500/values.yaml
@@ -69,7 +69,7 @@ operators:
       sourceNamespace: openshift-marketplace
       startingCSV: elasticsearch-operator.5.1.1-36
     operatorgroup:
-      create: false
+      create: true
 
   - name: cluster-logging-operator
     namespace: openshift-logging

--- a/tooling/charts/do500/values.yaml
+++ b/tooling/charts/do500/values.yaml
@@ -60,7 +60,7 @@ operators:
       create: false
 
   - name: elasticsearch-operator
-    namespace: openshift-operators
+    namespace: openshift-operators-redhat
     subscription:
       channel: stable-5.1
       approval: Automatic


### PR DESCRIPTION
fix up these errors on install. add helm hooks, fixup yaml.

```
Error: unable to build kubernetes objects from release manifest: [unable to recognize "": no matches for kind "ClusterLogging" in version "logging.openshift.io/v1", error validating "": error validating data: ValidationError(Subscription.spec): missing required field "name" in com.coreos.operators.v1alpha1.Subscription.spec]
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Subscription.spec): missing required field "name" in com.coreos.operators.v1alpha1.Subscription.spec
```