### PR TITLE
🐁 ADD - jsonnet cli to CRW stack 🐁

### DIFF
--- a/codereadyworkspaces/stack/Dockerfile
+++ b/codereadyworkspaces/stack/Dockerfile
@@ -20,13 +20,14 @@ ENV ARGOCD_VERSION=2.0.5 \
     ZSH_VERSION=5.8 \
     ROX_VERSION=3.63.0 \
     KUBELINTER_VERSION=0.2.2 \
-    COSIGN_VERSION=1.0.0
+    COSIGN_VERSION=1.0.0 \
+    JSONNET_VERSION=0.17.0
 
 # this is based off of registry.redhat.io/codeready-workspaces/plugin-java8-rhel8
 ENV NODEJS_VERSION=14 \
     PYTHON_VERSION="3.9" \
     JAVA_HOME=/usr/lib/jvm/java-11-openjdk \
-    PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/usr/lib/jvm/java-11-openjdk/bin:/usr/bin:$PATH \
+    PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/usr/lib/jvm/java-11-openjdk/bin:/usr/bin:$HOME/go/bin:$PATH \
     MAVEN_URL=https://archive.apache.org/dist/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz \
     HOME=/home/developer \
     PROJECTS=/projects \
@@ -35,7 +36,7 @@ ENV NODEJS_VERSION=14 \
 RUN dnf -y module reset nodejs python39 && \
     dnf -y module enable python39:${PYTHON_VERSION} nodejs:$NODEJS_VERSION && \
     dnf -y install \
-      bash tar gzip unzip which findutils wget curl git procps-ng bzip2 java-11-openjdk java-11-openjdk-devel java-11-openjdk-headless python39 python39-devel python39-setuptools python39-pip nodejs npm nodejs-nodemon nss_wrapper zsh iputils bind-utils net-tools && \
+      bash tar gzip unzip which findutils wget curl git procps-ng bzip2 java-11-openjdk java-11-openjdk-devel java-11-openjdk-headless python39 python39-devel python39-setuptools python39-pip nodejs npm nodejs-nodemon nss_wrapper zsh iputils bind-utils net-tools go-toolset && \
     dnf -y -q clean all && rm -rf /var/cache/yum && \
     pip3.9 install pylint && \
     mkdir -p ${HOME} ${PROJECTS} /usr/share/maven && \
@@ -102,6 +103,15 @@ RUN curl -skL -o /usr/local/bin/cosign https://github.com/sigstore/cosign/releas
 RUN curl -skL -o /usr/local/bin/hey https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64 && \
     chmod 775 /usr/local/bin/hey && \
     echo "👋👋👋"
+
+# jsonnet & jsonnet bundler 
+RUN GO111MODULE="on" go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb github.com/brancz/gojsontoyaml && \
+    curl -skL -o /tmp/jsonnet.tar.gz https://github.com/google/jsonnet/releases/download/v${JSONNET_VERSION}/jsonnet-bin-v${JSONNET_VERSION}-linux.tar.gz && \
+    tar -C /tmp -xzf /tmp/jsonnet.tar.gz && \
+    mv -v /tmp/jsonnet /usr/local/bin && \
+    chmod -R 775 /usr/local/bin/jsonnet && \
+    rm -rf /tmp/jsonnet* && \
+    echo "🎺🎺🎺🎺"
 
 # docsify-cli
 RUN npm i -g docsify-cli && \

--- a/codereadyworkspaces/stack/VERSION
+++ b/codereadyworkspaces/stack/VERSION
@@ -1,2 +1,1 @@
-VERSION=3.0.8
-
+VERSION=3.0.9

--- a/codereadyworkspaces/tl112-devfile.yaml
+++ b/codereadyworkspaces/tl112-devfile.yaml
@@ -1,0 +1,91 @@
+apiVersion: 1.0.0
+metadata:
+  name: tl112
+  generateName: tl112-
+projects:
+  - name: sre-enablement-content
+    clonePath: sre-enablement-content
+    source:
+      type: git
+      location: 'https://github.com/rht-labs/sre-enablement-content.git'
+      branch: 'main'
+components:
+  - type: cheEditor
+    alias: theia-editor
+    id: eclipse/che-theia/latest
+    memoryLimit: 2Gi
+  - alias: exec-plugin
+    type: chePlugin
+    id: eclipse/che-machine-exec-plugin/latest
+  - alias: node-debug2
+    type: chePlugin
+    id: ms-vscode/node-debug2/latest
+  - alias: vscode-yaml
+    type: chePlugin
+    id: redhat/vscode-yaml/latest
+  - type: dockerimage
+    alias: stack-tl112
+    image: quay.io/rht-labs/stack-tl112:3.0.9
+    memoryLimit: 2Gi
+    mountSources: true
+    command: ['/bin/sh', '-c', 'sleep infinity']
+    volumes:
+      - name: projects
+        containerPath: /projects
+      - name: config
+        containerPath: /home/developer/.config
+      - name: npm
+        containerPath: /home/developer/.npm
+    endpoints:
+      - name: ide-8080
+        port: 8080
+        attributes:
+          discoverable: "true"
+          public: "true"
+          protocol: http
+      - name: ide-9000
+        port: 9000
+        attributes:
+          discoverable: "true"
+          public: "true"
+          protocol: http
+      - name: ide-3000
+        port: 3000
+        attributes:
+          discoverable: "true"
+          public: "true"
+          protocol: http
+      - name: ide-4200
+        port: 4200
+        attributes:
+          discoverable: "true"
+          public: "true"
+          protocol: http
+      - name: ide-4444
+        port: 4444
+        attributes:
+          protocol: http
+      - name: ide-8081
+        port: 8081
+        attributes:
+          discoverable: "true"
+          public: "true"
+          protocol: http
+      - name: ide-8082
+        port: 8082
+        attributes:
+          discoverable: "true"
+          public: "true"
+          protocol: http
+      - name: ide-8083
+        port: 8083
+        attributes:
+          discoverable: "true"
+          public: "true"
+          protocol: http
+      - name: ide-8084
+        port: 8084
+        attributes:
+          discoverable: "true"
+          public: "true"
+          protocol: http


### PR DESCRIPTION
I didn't want to create a separate container image for SRE Enablement as most of the CLIs are in common. I just added jsonnet and jsonnet bundler cli (which will be used for PrometheusRule and Grafana dashboards creation). 

I created a separate devfile though, as some paths seem to be different for now. (but I'll look to make it common also)
I named it as `tl112` but I know that's not the actual name - it is temporary for my tests :)

@eformat - what do you think? thanks!