### PR TITLE
🌊 move to rh gitops operator chart 🌊

### DIFF
--- a/tooling/README.md
+++ b/tooling/README.md
@@ -12,6 +12,7 @@ This chart is capable of deploying the following:
 - Advanced Cluster Security (StackRox)
 - Cluster Logging (ELK)
 - Certificate Utils
+- GitOps Operator (ArgoCD)
 
 ## Installation
 

--- a/tooling/charts/do500/Chart.yaml
+++ b/tooling/charts/do500/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: do500
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: 0.0.1
 maintainers:
   - name: eformat
@@ -20,3 +20,7 @@ dependencies:
     version: "0.0.1"
     repository: https://redhat-cop.github.io/helm-charts
     condition: stackrox.enabled
+  - name: gitops-operator
+    version: "0.0.1"
+    repository: https://redhat-cop.github.io/helm-charts
+    condition: gitops-operator.enabled

--- a/tooling/charts/do500/values.yaml
+++ b/tooling/charts/do500/values.yaml
@@ -166,3 +166,8 @@ stackrox:
   enabled: true
   clusterName: do500
   namespace: stackrox
+
+gitops-operator:
+  enabled: true
+  namespaces:
+  ignoreHelmHooks: true

--- a/tooling/charts/do500/values.yaml
+++ b/tooling/charts/do500/values.yaml
@@ -115,7 +115,7 @@ gitlab:
     - name: "postgresql"
       tag_name: "latest"
       stream_uri: "registry.redhat.io/rhscl/postgresql-96-rhel7"
-#  ldap:
+  ldap:
 #    port: "389"
 #    base: "dc=CORP,dc=EXAMPLE,dc=COM"
 #    uri: "MY-LDAP.example.corp.com"
@@ -123,7 +123,7 @@ gitlab:
 #    validate_certs: "false"
 #    bind_dn: uid=ldap-admin,cn=users,cn=accounts,dc=CORP,dc=EXAMPLE,dc=COM
 #    password: password
-#    secret_name: ldap-bind-password
+    secret_name: ldap-bind-password
 
 crw:
   namespace: do500-workspaces
@@ -169,5 +169,5 @@ stackrox:
 
 gitops-operator:
   enabled: true
-  namespaces:
-  ignoreHelmHooks: true
+  namespaces: []
+  ignoreHelmHooks: false


### PR DESCRIPTION
Move to start using the Red Hat GitOps Operator. Pulled in as a chart dep.
This configuration will install the cluster wide Subscription only.
Individual ArgoCD's will be configured as part of enablement. 