### PR TITLE
Modify version reference on helm-release.yaml to match branch

### DIFF
--- a/helm-release.yaml
+++ b/helm-release.yaml
@@ -7,5 +7,5 @@ spec:
   releaseName: do500 
   chart:
     git: https://github.com/rht-labs/enablement-framework
-    ref: v1.0.0
+    ref: main
     path: tooling/charts/do500 


### PR DESCRIPTION
helm-release.yaml  on `main` still holds reference to `v1.0.0` of Helm Chart. 
I've updated it to match branch to unblock testing 