### PR TITLE
remove 'tl500' prefix from IdM group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # enablement-framework
 
-This repository contains the components needed to run a tl500 enablement session.
+This repository contains the components needed to run a TL500 enablement session.
 
 [Tooling](https://github.com/rht-labs/enablement-framework/tree/main/tooling) - The required tools to deploy once a cluster is available

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -1,6 +1,6 @@
-# tl500 Cluster Tooling
+# TL500 Cluster Tooling
 
-This directory contains the necessary charts used in order to deploy a tl500 Tech Stack against an OCP 4.X cluster. This assumes that the cluster has valid certificates.
+This directory contains the necessary charts used in order to deploy a TL500 Tech Stack against an OCP 4.X cluster. This assumes that the cluster has valid certificates.
 
 This chart is capable of deploying the following:
 

--- a/tooling/charts/tl500/values.yaml
+++ b/tooling/charts/tl500/values.yaml
@@ -4,8 +4,8 @@ gitlab_app_name: "gitlab-ce"
 # Create a helper to create a prefix if one isn't provided? Would help if we moved to shared clusters
 prefix: ""
 
-# Group name in LDAP / FreeIPA for attendees 
-group_name: tl500-participant
+# Group name in LDAP / IdM (FreeIPA) for attendees 
+group_name: student
 
 namespaces:
   - name: tl500-workspaces


### PR DESCRIPTION
@springdo @ckavili after further conversation around IdM group naming, we believe we'll be best off keeping it a bit more generic. Hence this PR. Let us know if you believe this will cause any sort of conflicts/issues for your side. 

Also, capitalizing a few places where PR #71 made them lower case

@jfilipcz @makirill FYI