### PR TITLE
🍄 fix ES logging deployment 🍄

### DIFF
--- a/tooling/charts/tl500/values.yaml
+++ b/tooling/charts/tl500/values.yaml
@@ -51,7 +51,7 @@ operators:
       create: false
 
   - name: elasticsearch-operator
-    namespace: openshift-operators-redhat
+    namespace: openshift-operators
     subscription:
       channel: stable-5.2
       approval: Automatic
@@ -60,7 +60,7 @@ operators:
       sourceNamespace: openshift-marketplace
       startingCSV: elasticsearch-operator.5.2.3-31
     operatorgroup:
-      create: true
+      create: false
 
   - name: cluster-logging-operator
     namespace: openshift-logging


### PR DESCRIPTION
The OpenShift Elasticsearch operator needs to be deployed at cluster scope for logging. Else you do not get kibana and es deployed when deploying logging. Frustratingly you dont even get an error in the logging oeprator pod !!

The chart template for OperatorGroups supports namespaced only.
So, for tl500, chuck this into openshift-operators namespace, which is fine (and has a cluster scoped OG) since we are not working about other Elastic stack stuff during tl500.

Working output in testing cluster
```
NAME                                            READY   STATUS      RESTARTS   AGE
cluster-logging-operator-6f79c557b9-6v74d       1/1     Running     0          25m
collector-7l4l5                                 2/2     Running     0          23m
collector-8f9bz                                 2/2     Running     0          22m
collector-8pd9l                                 2/2     Running     0          22m
collector-dc8nb                                 2/2     Running     0          22m
collector-j42h2                                 2/2     Running     0          23m
collector-l4lqx                                 2/2     Running     0          22m
collector-zmz8t                                 2/2     Running     0          23m
elasticsearch-cdm-wd5nf2ve-1-7cd4f7fbc5-5s98h   2/2     Running     0          17m
elasticsearch-im-app-27335580--1-j25gm          0/1     Completed   0          11m
elasticsearch-im-audit-27335580--1-cpmbz        0/1     Completed   0          11m
elasticsearch-im-infra-27335580--1-c9j9p        0/1     Completed   0          11m
kibana-7cb5964777-kb2n5                         2/2     Running     0          17m
```