### PR TITLE
🦙 fix tl500 in stackrox sub chart dep 🦙

### DIFF
--- a/tooling/charts/tl500/values.yaml
+++ b/tooling/charts/tl500/values.yaml
@@ -162,10 +162,11 @@ sealed-secrets:
 
 userworkloadmonitoring: true
 
-stackrox:
+stackrox-chart:
   enabled: true
-  clusterName: tl500
-  namespace: stackrox
+  stackrox:
+    clusterName: tl500
+    namespace: stackrox
 
 gitops-operator:
   enabled: true


### PR DESCRIPTION
sub chart dep for stackrox was stuck on do500 .. values were not getting substituted correctly because the chart is named "stackrox-chart" not "stackrox"

this fixes values substitution in dependency sub chart 