### PR TITLE
Correcting GH pages URL for Helm Charts

### DIFF
--- a/.github/workflows/tl500-release.yml
+++ b/.github/workflows/tl500-release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Index the Helm Charts
         run: |
-          helm repo index --url https://enablement-framework.rht-labs.github.io . 
+          helm repo index --url https://rht-labs.com/enablement-framework .
 
       - name: Publish the updated Charts
         run: |


### PR DESCRIPTION
Since we have a different DNS/URL format than standard GH Pages, this PR changes the URL to use our Labs format. 