### PR TITLE
Updating helper function to allow for a complete GitLab LDAP definition

### DIFF
--- a/tooling/charts/tl500/templates/_helpers.tpl
+++ b/tooling/charts/tl500/templates/_helpers.tpl
@@ -64,11 +64,13 @@
 {{- end -}}
 
 {{- define "gitlab.ldap.bind_password" -}}
+{{- if $.Values.gitlab.ldap.password -}}
+{{ $.Values.gitlab.ldap.password }}
+{{- else -}}
 {{- $secret := include "gitlab.ldap.secret_name" . -}}
 {{- if (lookup "v1" "Secret" "openshift-config" $secret ) }}
 {{- print (lookup "v1" "Secret" "openshift-config" $secret ).data.bindPassword | b64dec -}}
-{{- else -}}
-{{ $.Values.gitlab.ldap.password }}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
This aligns with the rest of the functionality in this template file for `gitlab.ldap` definitions.

This will also allow for a `helm template` run to successfully complete (as the `lookup` functionality isn't supported with `helm template`). 