### PR TITLE
🐑 install tl500 into 4.10 cluster 🐑

### DIFF
--- a/tooling/charts/tl500/Chart.yaml
+++ b/tooling/charts/tl500/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tl500
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.0.1
 maintainers:
   - name: eformat
@@ -21,6 +21,6 @@ dependencies:
     repository: https://redhat-cop.github.io/helm-charts
     condition: stackrox.enabled
   - name: gitops-operator
-    version: "0.2.0"
+    version: "0.2.4"
     repository: https://redhat-cop.github.io/helm-charts
     condition: gitops-operator.enabled

--- a/tooling/charts/tl500/values.yaml
+++ b/tooling/charts/tl500/values.yaml
@@ -11,20 +11,18 @@ namespaces:
   - name: tl500-workspaces
   - name: tl500-gitlab
   - name: tl500-shared
-#  - name: tl500-slides
 
 operators:
   - name: codeready-workspaces
-    namespace: openshift-operators
+    namespace: tl500-workspaces
     subscription:
       channel: latest
       approval: Automatic
       operatorName: codeready-workspaces
       sourceName: redhat-operators
       sourceNamespace: openshift-marketplace
-      csv: crwoperator.v2.14.0
     operatorgroup:
-      create: false
+      create: true
 
   - name: openshift-pipelines-operator-rh
     namespace: openshift-operators
@@ -34,7 +32,6 @@ operators:
       operatorName: openshift-pipelines-operator-rh
       sourceName: redhat-operators
       sourceNamespace: openshift-marketplace
-      csv: openshift-pipelines-operator-rh.v1.6.1
     operatorgroup:
       create: false
 
@@ -46,31 +43,28 @@ operators:
       operatorName: cert-utils-operator
       sourceName: community-operators
       sourceNamespace: openshift-marketplace
-      csv: cert-utils-operator.v1.3.2
     operatorgroup:
       create: false
 
   - name: elasticsearch-operator
     namespace: openshift-operators
     subscription:
-      channel: stable-5.2
+      channel: stable-5.3
       approval: Automatic
       operatorName: elasticsearch-operator
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: elasticsearch-operator.5.2.3-31
     operatorgroup:
       create: false
 
   - name: cluster-logging-operator
     namespace: openshift-logging
     subscription:
-      channel: stable-5.2
+      channel: stable-5.3
       approval: Automatic
       operatorName: cluster-logging
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: cluster-logging.5.2.3-31
     operatorgroup:
       create: true
 


### PR DESCRIPTION
installed tl500 chart into 4.10-rc2 cluster
removed csv starting args (just auto install latest stable channels)
CRW changed namespaces required (can't be in openshift-operators)

i will be testing tl500 tech-exercises against this env