### PR TITLE
🧸 stackox scanner resource limits 🧸

### DIFF
--- a/tooling/charts/tl500/Chart.yaml
+++ b/tooling/charts/tl500/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tl500
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: 0.0.1
 maintainers:
   - name: eformat
@@ -17,7 +17,7 @@ dependencies:
     repository: https://bitnami-labs.github.io/sealed-secrets
     condition: sealed-secrets.enabled
   - name: stackrox-chart
-    version: "0.0.1"
+    version: "0.0.2"
     repository: https://redhat-cop.github.io/helm-charts
     condition: stackrox.enabled
   - name: gitops-operator


### PR DESCRIPTION
updates the chart dep for stackrox which adds scanner pod resource limits - defaults are:

```
  scanner:
    analyzer:
      resources:
        limits:
          cpu: 500m
        requests:
          cpu: 100m
```