### PR TITLE
Add fixed operators values file for Labs SRE Automation

### DIFF
--- a/tooling/charts/tl500/fixed-operators-versions.yaml
+++ b/tooling/charts/tl500/fixed-operators-versions.yaml
@@ -1,0 +1,64 @@
+
+operators:
+  - name: codeready-workspaces2
+    namespace: tl500-workspaces
+    subscription:
+      channel: latest
+      approval: Manual
+      operatorName: codeready-workspaces
+      sourceName: redhat-operators
+      sourceNamespace: openshift-marketplace
+      csv: crwoperator.v2.14.0
+    operatorgroup:
+      create: true
+
+  - name: openshift-pipelines-operator-rh
+    namespace: openshift-operators
+    subscription:
+      channel: stable
+      approval: Manual
+      operatorName: openshift-pipelines-operator-rh
+      sourceName: redhat-operators
+      sourceNamespace: openshift-marketplace
+      csv: openshift-pipelines-operator-rh.v1.6.2
+    operatorgroup:
+      create: false
+
+  - name: cert-utils-operator
+    namespace: openshift-operators
+    subscription:
+      channel: alpha
+      approval: Manual
+      operatorName: cert-utils-operator
+      sourceName: community-operators
+      sourceNamespace: openshift-marketplace
+      csv: cert-utils-operator.v1.3.2
+    operatorgroup:
+      create: false
+
+  - name: elasticsearch-operator
+    namespace: openshift-operators
+    subscription:
+      channel: stable-5.2
+      approval: Manual
+      operatorName: elasticsearch-operator
+      source: redhat-operators
+      sourceNamespace: openshift-marketplace
+      startingCSV: elasticsearch-operator.5.2.3-31
+    operatorgroup:
+      create: false
+
+  - name: cluster-logging-operator
+    namespace: cluster-logging
+    subscription:
+      channel: stable-5.2
+      approval: Manual
+      operatorName: cluster-logging
+      source: redhat-operators
+      sourceNamespace: openshift-marketplace
+      startingCSV: cluster-logging.5.2.3-31
+    operatorgroup:
+      create: true
+
+logging:
+   namespace: "cluster-logging"


### PR DESCRIPTION
This PR adds a values.yaml type of the file to keep fixed operator versions for use with Labs SRE Automation