### PR TITLE
🩸 use latest gitops-operator chart 🩸

### DIFF
--- a/tooling/charts/tl500-base/Chart.yaml
+++ b/tooling/charts/tl500-base/Chart.yaml
@@ -21,6 +21,6 @@ dependencies:
     repository: https://redhat-cop.github.io/helm-charts
     condition: stackrox-chart.enabled
   - name: gitops-operator
-    version: "0.2.4"
+    version: "0.3.2"
     repository: https://redhat-cop.github.io/helm-charts
     condition: gitops-operator.enabled


### PR DESCRIPTION
bump this to the latest version as we want this fix

https://github.com/redhat-cop/helm-charts/blob/master/charts/gitops-operator/templates/subscription.yaml#L19-L21

which only sets ARGOCD_CLUSTER_CONFIG_NAMESPACES if you add namespaces list and teamInstancesAreClusterScoped - else we get an empty value here which is undesirable. 