### PR TITLE
🍒 switch pipelines to the latest channel 🍒

### DIFF
--- a/tooling/charts/tl500-base/values.yaml
+++ b/tooling/charts/tl500-base/values.yaml
@@ -28,7 +28,7 @@ operators:
   - name: openshift-pipelines-operator-rh
     namespace: openshift-operators
     subscription:
-      channel: stable
+      channel: latest
       approval: Automatic
       operatorName: openshift-pipelines-operator-rh
       sourceName: redhat-operators


### PR DESCRIPTION
merging this, needed to fix TL500 course content deployment

```
failed: [bastion.w79pf.internal] (item=helm upgrade --install tl500-course-content . --namespace tl500 --create-namespace --timeout=20m) => {"ansible_loop_var": "item", "changed": true, "cmd": ["helm", "upgrade", "--install", "tl500-course-content", ".", "--namespace", "tl500", "--create-namespace", "--timeout=20m"], "delta": "0:20:23.938484", "end": "2022-05-11 00:55:19.478627", "item": "helm upgrade --install tl500-course-content . --namespace tl500 --create-namespace --timeout=20m", "msg": "non-zero return code", "rc": 1, "start": "2022-05-11 00:34:55.540143", "stderr": "Error: failed post-install: timed out waiting for the condition", "stderr_lines": ["Error: failed post-install: timed out waiting for the condition"], "stdout": "Release \"tl500-course-content\" does not exist. Installing it now.", "stdout_lines": ["Release \"tl500-course-content\" does not exist. Installing it now."]}
```