### PR TITLE
Bump gitops operator to latest (v1.5.2)

### DIFF
--- a/tooling/charts/tl500-base/Chart.yaml
+++ b/tooling/charts/tl500-base/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     repository: https://redhat-cop.github.io/helm-charts
     condition: stackrox-chart.enabled
   - name: gitops-operator
-    version: "0.3.2"
+    version: "0.3.8"
     repository: https://redhat-cop.github.io/helm-charts
     condition: gitops-operator.enabled
   - name: tl500-teamsters


### PR DESCRIPTION
Dependant on https://github.com/redhat-cop/helm-charts/pull/266 being merged and released under v0.3.8