### PR TITLE
Bump versions on StackRox and Gitops operator

### DIFF
--- a/tooling/charts/tl500-base/Chart.yaml
+++ b/tooling/charts/tl500-base/Chart.yaml
@@ -17,11 +17,11 @@ dependencies:
     repository: https://bitnami-labs.github.io/sealed-secrets
     condition: sealed-secrets.enabled
   - name: stackrox-chart
-    version: "0.0.4"
+    version: "0.0.5"
     repository: https://redhat-cop.github.io/helm-charts
     condition: stackrox-chart.enabled
   - name: gitops-operator
-    version: "0.3.8"
+    version: "0.3.9"
     repository: https://redhat-cop.github.io/helm-charts
     condition: gitops-operator.enabled
   - name: tl500-teamsters


### PR DESCRIPTION
Gitops Operator Chart -> 0.3.9 (Removal of StartingCSV)
StackRox Operator Chart -> 0.0.5 (RBAC fix)