### PR TITLE
🐹 argocd 2.4.7, gitops 1.6.0 🐹

### DIFF
--- a/tooling/charts/tl500-base/Chart.yaml
+++ b/tooling/charts/tl500-base/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     repository: https://redhat-cop.github.io/helm-charts
     condition: stackrox-chart.enabled
   - name: gitops-operator
-    version: "0.3.12"
+    version: "0.4.0"
     repository: https://redhat-cop.github.io/helm-charts
     condition: gitops-operator.enabled
   - name: tl500-teamsters


### PR DESCRIPTION
upadate for latest gitops operator - 1.6.0, matches this PR

https://github.com/redhat-cop/helm-charts/pull/281 