### PR TITLE
Parametrize ipa namespace

### DIFF
--- a/tooling/charts/tl500-base/templates/tl500-rbac.yaml
+++ b/tooling/charts/tl500-base/templates/tl500-rbac.yaml
@@ -119,14 +119,13 @@ subjects:
   kind: Group
   name: {{ .Values.group_name }}
 ---
-# to view tl500 IPA namespaces
-# Only if IPA namespace is there
-{{ if (lookup "v1" "Namespace" "" "ipa") }}
+{{- if .Values.ipa_namespace -}}
+# to view tl500 IPA namespaces. Only if IPA namespace exists.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tl500-ipa-view
-  namespace: ipa
+  namespace: {{ .Values.ipa_namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -135,7 +134,7 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: {{ .Values.group_name }}
-{{- end }}
+{{- end -}}
 ---
 # to edit/view monotoring
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tooling/charts/tl500-base/values.yaml
+++ b/tooling/charts/tl500-base/values.yaml
@@ -4,9 +4,11 @@ gitlab_app_name: "gitlab-ce"
 # Create a helper to create a prefix if one isn't provided? Would help if we moved to shared clusters
 prefix: ""
 
-# Group name in LDAP / IdM (FreeIPA) for attendees 
+# Group name in LDAP / IdM (FreeIPA) for attendees.
 group_name: student
 
+# Namespace where IDM runs, in case is deployed in OCP. Otherwise leave it empty or blank.
+ipa_namespace: ipa
 
 namespaces:
   - name: tl500-workspaces
@@ -75,7 +77,6 @@ operators:
      operatorgroup:
        create: false
 
-
 logging:
   # Might be needed with clusters that have an infra plane
   # nodeSelector:
@@ -135,4 +136,3 @@ gitops-operator:
 
 tl500-teamsters:
   enabled: true
-


### PR DESCRIPTION
Parametrize IPA namespace and also make it optional to support deployments where IPA/IDM is deployed outside OpenShift, like the GLS environments.