### PR TITLE
Improve TL500-course-content backward compability

### DIFF
--- a/tooling/charts/tl500-course-content/templates/docs/configmap.yaml
+++ b/tooling/charts/tl500-course-content/templates/docs/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.docs }}
 {{- if .Values.docs.config }}
 ---
 apiVersion: v1
@@ -7,4 +8,5 @@ metadata:
   namespace: {{ $.Values.docs.namespace }}
 data:
   all.json: {{ $.Values.docs.config.configFileContent }}
+{{- end }}
 {{- end }}

--- a/tooling/charts/tl500-course-content/templates/docs/deploy.yaml
+++ b/tooling/charts/tl500-course-content/templates/docs/deploy.yaml
@@ -14,7 +14,7 @@ spec:
       app: "{{ .Values.docs.name }}"
   template:
     spec:
-{{- if .Values.docs.config }}
+{{- if and .Values.docs .Values.docs.config }}
       volumes:
         - name: {{ .Values.docs.config.configMapName }}
           configMap:
@@ -29,7 +29,7 @@ spec:
             - containerPort: 8080
               protocol: TCP
           resources: {}
-{{- if .Values.docs.config }}
+{{- if and .Values.docs .Values.docs.config }}
           volumeMounts:
             - name: {{ .Values.docs.config.configMapName }}
               mountPath: /docs/config


### PR DESCRIPTION
Add explicit check for both .Values.docs and .Values.docs.config in TL500 docs deployment and config