### PR TITLE
🧪devfile migrated to v2.1.0🧪

### DIFF
--- a/codereadyworkspaces/tl500-devfile.yaml
+++ b/codereadyworkspaces/tl500-devfile.yaml
@@ -12,8 +12,8 @@ components:
     container:
       image: quay.io/rht-labs/stack-tl500:3.0.16
       memoryLimit: 2Gi
-      mountSources: true
       args: ['/bin/sh', '-c', 'sleep infinity']
+      mountSources: true
       volumeMounts:
         - name: projects
           path: /projects
@@ -21,3 +21,12 @@ components:
           path: /home/developer/.config
         - name: npm
           path: /home/developer/.npm
+  - name: projects
+    volume:
+      size: 256Mi
+  - name: config
+    volume:
+      size: 256Mi
+  - name: npm
+    volume:
+      size: 256Mi

--- a/codereadyworkspaces/tl500-devfile.yaml
+++ b/codereadyworkspaces/tl500-devfile.yaml
@@ -1,10 +1,8 @@
-apiVersion: 2.1.0
+schemaVersion: 2.1.0
 metadata:
   name: tl500
   generateName: tl500-
-attributes:
-  che-theia.eclipse.org/sidecar-policy: USE_DEV_CONTAINER
-projects:
+starterProjects:
   - name: tech-exercise
     clonePath: tech-exercise
     source:
@@ -12,22 +10,6 @@ projects:
       location: 'https://github.com/rht-labs/tech-exercise'
       branch: 'main'
 components:
-  # - type: cheEditor
-  #   alias: theia-editor
-  #   id: eclipse/che-theia/latest
-  #   memoryLimit: 2Gi
-  # - alias: exec-plugin
-  #   type: chePlugin
-  #   id: eclipse/che-machine-exec-plugin/latest
-  # - alias: node-debug2
-  #   type: chePlugin
-  #   id: ms-vscode/node-debug2/latest
-  # - alias: vscode-yaml
-  #   type: chePlugin
-  #   id: redhat/vscode-yaml/latest
-  # - alias: typescript-language-features
-  #   type: chePlugin
-  #   id: vscode/typescript-language-features/latest
   - type: dockerimage
     alias: stack-tl500
     image: quay.io/rht-labs/stack-tl500:3.0.16
@@ -41,56 +23,3 @@ components:
         containerPath: /home/developer/.config
       - name: npm
         containerPath: /home/developer/.npm
-    # endpoints:
-    #   - name: ide-8080
-    #     port: 8080
-    #     attributes:
-    #       discoverable: "true"
-    #       public: "true"
-    #       protocol: http
-    #   - name: ide-9000
-    #     port: 9000
-    #     attributes:
-    #       discoverable: "true"
-    #       public: "true"
-    #       protocol: http
-    #   - name: ide-3000
-    #     port: 3000
-    #     attributes:
-    #       discoverable: "true"
-    #       public: "true"
-    #       protocol: http
-    #   - name: ide-4200
-    #     port: 4200
-    #     attributes:
-    #       discoverable: "true"
-    #       public: "true"
-    #       protocol: http
-    #   - name: ide-4444
-    #     port: 4444
-    #     attributes:
-    #       protocol: http
-    #   - name: ide-8081
-    #     port: 8081
-    #     attributes:
-    #       discoverable: "true"
-    #       public: "true"
-    #       protocol: http
-    #   - name: ide-8082
-    #     port: 8082
-    #     attributes:
-    #       discoverable: "true"
-    #       public: "true"
-    #       protocol: http
-    #   - name: ide-8083
-    #     port: 8083
-    #     attributes:
-    #       discoverable: "true"
-    #       public: "true"
-    #       protocol: http
-    #   - name: ide-8084
-    #     port: 8084
-    #     attributes:
-    #       discoverable: "true"
-    #       public: "true"
-    #       protocol: http

--- a/codereadyworkspaces/tl500-devfile.yaml
+++ b/codereadyworkspaces/tl500-devfile.yaml
@@ -2,13 +2,11 @@ schemaVersion: 2.1.0
 metadata:
   name: tl500
   generateName: tl500-
-starterProjects:
+projects:
   - name: tech-exercise
-    clonePath: tech-exercise
-    source:
-      type: git
-      location: 'https://github.com/rht-labs/tech-exercise'
-      branch: 'main'
+    git:
+      remotes:
+        origin: 'https://github.com/rht-labs/tech-exercise.git'
 components:
   - type: dockerimage
     alias: stack-tl500

--- a/codereadyworkspaces/tl500-devfile.yaml
+++ b/codereadyworkspaces/tl500-devfile.yaml
@@ -1,7 +1,9 @@
-apiVersion: 1.0.0
+apiVersion: 2.1.0
 metadata:
   name: tl500
   generateName: tl500-
+attributes:
+  che-theia.eclipse.org/sidecar-policy: USE_DEV_CONTAINER
 projects:
   - name: tech-exercise
     clonePath: tech-exercise
@@ -10,22 +12,22 @@ projects:
       location: 'https://github.com/rht-labs/tech-exercise'
       branch: 'main'
 components:
-  - type: cheEditor
-    alias: theia-editor
-    id: eclipse/che-theia/latest
-    memoryLimit: 2Gi
-  - alias: exec-plugin
-    type: chePlugin
-    id: eclipse/che-machine-exec-plugin/latest
-  - alias: node-debug2
-    type: chePlugin
-    id: ms-vscode/node-debug2/latest
-  - alias: vscode-yaml
-    type: chePlugin
-    id: redhat/vscode-yaml/latest
-  - alias: typescript-language-features
-    type: chePlugin
-    id: vscode/typescript-language-features/latest
+  # - type: cheEditor
+  #   alias: theia-editor
+  #   id: eclipse/che-theia/latest
+  #   memoryLimit: 2Gi
+  # - alias: exec-plugin
+  #   type: chePlugin
+  #   id: eclipse/che-machine-exec-plugin/latest
+  # - alias: node-debug2
+  #   type: chePlugin
+  #   id: ms-vscode/node-debug2/latest
+  # - alias: vscode-yaml
+  #   type: chePlugin
+  #   id: redhat/vscode-yaml/latest
+  # - alias: typescript-language-features
+  #   type: chePlugin
+  #   id: vscode/typescript-language-features/latest
   - type: dockerimage
     alias: stack-tl500
     image: quay.io/rht-labs/stack-tl500:3.0.16
@@ -39,56 +41,56 @@ components:
         containerPath: /home/developer/.config
       - name: npm
         containerPath: /home/developer/.npm
-    endpoints:
-      - name: ide-8080
-        port: 8080
-        attributes:
-          discoverable: "true"
-          public: "true"
-          protocol: http
-      - name: ide-9000
-        port: 9000
-        attributes:
-          discoverable: "true"
-          public: "true"
-          protocol: http
-      - name: ide-3000
-        port: 3000
-        attributes:
-          discoverable: "true"
-          public: "true"
-          protocol: http
-      - name: ide-4200
-        port: 4200
-        attributes:
-          discoverable: "true"
-          public: "true"
-          protocol: http
-      - name: ide-4444
-        port: 4444
-        attributes:
-          protocol: http
-      - name: ide-8081
-        port: 8081
-        attributes:
-          discoverable: "true"
-          public: "true"
-          protocol: http
-      - name: ide-8082
-        port: 8082
-        attributes:
-          discoverable: "true"
-          public: "true"
-          protocol: http
-      - name: ide-8083
-        port: 8083
-        attributes:
-          discoverable: "true"
-          public: "true"
-          protocol: http
-      - name: ide-8084
-        port: 8084
-        attributes:
-          discoverable: "true"
-          public: "true"
-          protocol: http
+    # endpoints:
+    #   - name: ide-8080
+    #     port: 8080
+    #     attributes:
+    #       discoverable: "true"
+    #       public: "true"
+    #       protocol: http
+    #   - name: ide-9000
+    #     port: 9000
+    #     attributes:
+    #       discoverable: "true"
+    #       public: "true"
+    #       protocol: http
+    #   - name: ide-3000
+    #     port: 3000
+    #     attributes:
+    #       discoverable: "true"
+    #       public: "true"
+    #       protocol: http
+    #   - name: ide-4200
+    #     port: 4200
+    #     attributes:
+    #       discoverable: "true"
+    #       public: "true"
+    #       protocol: http
+    #   - name: ide-4444
+    #     port: 4444
+    #     attributes:
+    #       protocol: http
+    #   - name: ide-8081
+    #     port: 8081
+    #     attributes:
+    #       discoverable: "true"
+    #       public: "true"
+    #       protocol: http
+    #   - name: ide-8082
+    #     port: 8082
+    #     attributes:
+    #       discoverable: "true"
+    #       public: "true"
+    #       protocol: http
+    #   - name: ide-8083
+    #     port: 8083
+    #     attributes:
+    #       discoverable: "true"
+    #       public: "true"
+    #       protocol: http
+    #   - name: ide-8084
+    #     port: 8084
+    #     attributes:
+    #       discoverable: "true"
+    #       public: "true"
+    #       protocol: http

--- a/codereadyworkspaces/tl500-devfile.yaml
+++ b/codereadyworkspaces/tl500-devfile.yaml
@@ -8,16 +8,16 @@ projects:
       remotes:
         origin: 'https://github.com/rht-labs/tech-exercise.git'
 components:
-  - type: dockerimage
-    alias: stack-tl500
-    image: quay.io/rht-labs/stack-tl500:3.0.16
-    memoryLimit: 2Gi
-    mountSources: true
-    args: ['/bin/sh', '-c', 'sleep infinity']
-    volumes:
-      - name: projects
-        containerPath: /projects
-      - name: config
-        containerPath: /home/developer/.config
-      - name: npm
-        containerPath: /home/developer/.npm
+  - name: stack-tl500
+    container:
+      image: quay.io/rht-labs/stack-tl500:3.0.16
+      memoryLimit: 2Gi
+      mountSources: true
+      args: ['/bin/sh', '-c', 'sleep infinity']
+      volumeMounts:
+        - name: projects
+          path: /projects
+        - name: config
+          path: /home/developer/.config
+        - name: npm
+          path: /home/developer/.npm


### PR DESCRIPTION
Due to the changes on devspaces and the following error on OpenShift 4.11, devfile is migrated to v2.1.0.

```
Danger alert:
Failed to create a workspace. Failed to create a new workspace from the devfile, reason: Unable to resolve theia plugins: eclipse/che-machine-exec-plugin/latest is a mandatory plug-in but definition is not found on the plug-in registry. Aborting !
```

However, I am not sure if this devfile would work on OpenShift 4.10 or before. I don't have an OpenShift 4.10 to try at the moment 🫣🫣 If it works, it is good! But since in tech-exercise documentation, we are directly pointing to main [devfile](https://rht-labs.com/tech-exercise/#/1-the-manual-menace/1-the-basics), maybe we need to hold this to merge? 

Should we update tech-exercise to point to a specific version? I am not sure if everyone is going to run TL500 on OpenShift 4.11 🤷🏻‍♀️ What do you think @eformat @springdo? 👀

