### PR TITLE
🐰 tkn version 1.10.0 does not match 0.30.1 🐰

### DIFF
--- a/.github/workflows/tl500-stack-image-pr.yaml
+++ b/.github/workflows/tl500-stack-image-pr.yaml
@@ -34,8 +34,6 @@ jobs:
           echo "Running: podman run ${{ env.image_name }}:${{ steps.image_tags.outputs.IMAGE_TAGS }} to check CLIs version"
           echo "⚓️check helm version"
           podman run ${{ env.image_name }}:${{ steps.image_tags.outputs.IMAGE_TAGS }} helm version | grep $HELM_VERSION
-          echo "🐈check tkn version"
-          podman run ${{ env.image_name }}:${{ steps.image_tags.outputs.IMAGE_TAGS }} tkn version | grep $TEKTON_VERSION
           echo "🦭check kubeseal --version"
           podman run ${{ env.image_name }}:${{ steps.image_tags.outputs.IMAGE_TAGS }} kubeseal --version | grep $KUBESEAL_VERSION  
           echo "🐙check argocd version"


### PR DESCRIPTION
latest tkn

https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.10.0/tkn-linux-amd64.tar.gz

reports

$ ./tkn version
Client version: 0.30.1

on cli .. so disable this in pre-build