### PR TITLE
🔒make gitlab credentials idempotent 🔒

### DIFF
--- a/tooling/charts/tl500-base/Chart.yaml
+++ b/tooling/charts/tl500-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tl500-base
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.1
 maintainers:
   - name: eformat

--- a/tooling/charts/tl500-base/templates/_helpers.tpl
+++ b/tooling/charts/tl500-base/templates/_helpers.tpl
@@ -92,9 +92,10 @@
 {{- end -}}
 
 {{- define "gitlab.root_password" -}}
+{{- $secretName := (printf "%v-credentials" .Values.gitlab.app_name) -}}
 {{- $password := default (randAlphaNum 10) .Values.gitlab.credentials.root_password }}
 {{- if not .Values.gitlab.credentials.root_password }}
-{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace "gitlab-credentials") }}
+{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace $secretName) }}
 {{- if $existingSecret }}
 {{- $password = index $existingSecret.data "root_password" | b64dec }}
 {{- end -}}
@@ -103,9 +104,10 @@
 {{- end -}}
 
 {{- define "gitlab.postgres.user" -}}
+{{- $secretName := (printf "%v-credentials" .Values.gitlab.app_name) -}}
 {{- $username := default (randAlphaNum 10) .Values.gitlab.credentials.postgres_user }}
 {{- if not .Values.gitlab.credentials.postgres_user }}
-{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace "gitlab-credentials") }}
+{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace $secretName) }}
 {{- if $existingSecret }}
 {{- $username = index $existingSecret.data "postgres_user" | b64dec }}
 {{- end -}}
@@ -114,9 +116,10 @@
 {{- end -}}
 
 {{- define "gitlab.postgres.password" -}}
+{{- $secretName := (printf "%v-credentials" .Values.gitlab.app_name) -}}
 {{- $password := default (randAlphaNum 10) .Values.gitlab.credentials.postgres_password }}
 {{- if not .Values.gitlab.credentials.postgres_password }}
-{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace "gitlab-credentials") }}
+{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace $secretName) }}
 {{- if $existingSecret }}
 {{- $password = index $existingSecret.data "postgres_password" | b64dec }}
 {{- end -}}
@@ -125,9 +128,10 @@
 {{- end -}}
 
 {{- define "gitlab.postgres.admin_password" -}}
+{{- $secretName := (printf "%v-credentials" .Values.gitlab.app_name) -}}
 {{- $password := default (randAlphaNum 10) .Values.gitlab.credentials.postgres_admin_password }}
 {{- if not .Values.gitlab.credentials.postgres_admin_password }}
-{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace "gitlab-credentials") }}
+{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace $secretName) }}
 {{- if $existingSecret }}
 {{- $password = index $existingSecret.data "postgres_admin_password" | b64dec }}
 {{- end -}}

--- a/tooling/charts/tl500-base/templates/_helpers.tpl
+++ b/tooling/charts/tl500-base/templates/_helpers.tpl
@@ -92,17 +92,45 @@
 {{- end -}}
 
 {{- define "gitlab.root_password" -}}
-{{- print (randAlphaNum 10) -}}
+{{- $password := default (randAlphaNum 10) .Values.gitlab.credentials.root_password }}
+{{- if not .Values.gitlab.credentials.root_password }}
+{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace "gitlab-credentials") }}
+{{- if $existingSecret }}
+{{- $password = index $existingSecret.data "root_password" | b64dec }}
+{{- end -}}
+{{- end -}}
+{{- print $password -}}
 {{- end -}}
 
 {{- define "gitlab.postgres.user" -}}
-{{- print (randAlphaNum 10) -}}
+{{- $username := default (randAlphaNum 10) .Values.gitlab.credentials.postgres_user }}
+{{- if not .Values.gitlab.credentials.postgres_user }}
+{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace "gitlab-credentials") }}
+{{- if $existingSecret }}
+{{- $username = index $existingSecret.data "postgres_user" | b64dec }}
+{{- end -}}
+{{- end -}}
+{{- print $username -}}
 {{- end -}}
 
 {{- define "gitlab.postgres.password" -}}
-{{- print (randAlphaNum 10) -}}
+{{- $password := default (randAlphaNum 10) .Values.gitlab.credentials.postgres_password }}
+{{- if not .Values.gitlab.credentials.postgres_password }}
+{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace "gitlab-credentials") }}
+{{- if $existingSecret }}
+{{- $password = index $existingSecret.data "postgres_password" | b64dec }}
+{{- end -}}
+{{- end -}}
+{{- print $password -}}
 {{- end -}}
 
 {{- define "gitlab.postgres.admin_password" -}}
-{{- print (randAlphaNum 10) -}}
+{{- $password := default (randAlphaNum 10) .Values.gitlab.credentials.postgres_admin_password }}
+{{- if not .Values.gitlab.credentials.postgres_admin_password }}
+{{- $existingSecret := (lookup "v1" "Secret" .Values.gitlab.namespace "gitlab-credentials") }}
+{{- if $existingSecret }}
+{{- $password = index $existingSecret.data "postgres_admin_password" | b64dec }}
+{{- end -}}
+{{- end -}}
+{{- print $password -}}
 {{- end -}}

--- a/tooling/charts/tl500-base/templates/gitlab/anyuid-scc.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/anyuid-scc.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:openshift:scc:anyuid
+  name: system:openshift:scc:anyuid-{{ .Values.gitlab.app_name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:openshift:scc:anyuid
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.gitlab_app_name }}-user
+  name: {{ .Values.gitlab.app_name }}-user
   namespace: {{ .Values.gitlab.namespace }}
 {{- end }}

--- a/tooling/charts/tl500-base/templates/gitlab/deployments.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/deployments.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.gitlab -}}
+{{ $root_pass := include "gitlab.root_password" . }}
 {{ $db_user := include "gitlab.postgres.user" . }}
 {{ $db_pass := include "gitlab.postgres.password" . }}
 {{ $db_admin_pass := include "gitlab.postgres.admin_password" . }}
@@ -72,7 +73,7 @@ spec:
         env:
         - name: GITLAB_OMNIBUS_CONFIG
           value:
-            root_pass='{{ $.Values.gitlab.root_password | default "kJ4e9qLkm4pOhQnbn7nE" }}';
+            root_pass='{{ $root_pass }}';
             external_url "https://{{ $.Values.gitlab_app_name }}.{{ include "tl500.app_domain" . }}";
             nginx['listen_port']=80;
             nginx['listen_https']=false;

--- a/tooling/charts/tl500-base/templates/gitlab/deployments.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/deployments.yaml
@@ -1,16 +1,12 @@
 {{- if .Values.gitlab -}}
-{{ $root_pass := include "gitlab.root_password" . }}
-{{ $db_user := include "gitlab.postgres.user" . }}
-{{ $db_pass := include "gitlab.postgres.password" . }}
-{{ $db_admin_pass := include "gitlab.postgres.admin_password" . }}
 ---
 kind: DeploymentConfig
 apiVersion: apps.openshift.io/v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}"
+  namespace: "{{ .Values.gitlab.namespace }}"
   labels:
-    app: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ .Values.gitlab.app_name }}"
 spec:
   strategy:
     type: Recreate
@@ -23,17 +19,17 @@ spec:
       - gitlab-ce
       from:
         kind: ImageStreamTag
-        name: "{{ $.Values.gitlab_app_name }}:gitlab-12.8.7"
+        name: "{{ .Values.gitlab.app_name }}-{{ .Values.gitlab.imagestreams.gitlab.name }}:{{ .Values.gitlab.imagestreams.gitlab.tag_name }}"
   replicas: 1
   test: false
   selector:
-    app: "{{ $.Values.gitlab_app_name }}"
-    deploymentconfig: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ .Values.gitlab.app_name }}"
+    deploymentconfig: "{{ .Values.gitlab.app_name }}"
   template:
     metadata:
       labels:
-        app: "{{ $.Values.gitlab_app_name }}"
-        deploymentconfig: "{{ $.Values.gitlab_app_name }}"
+        app: "{{ .Values.gitlab.app_name }}"
+        deploymentconfig: "{{ .Values.gitlab.app_name }}"
     spec:
       {{- if .Values.runOnInfra }}
       nodeSelector:
@@ -49,10 +45,10 @@ spec:
       volumes:
       - name: gitlab-ce-volume-1
         persistentVolumeClaim:
-          claimName: "{{ $.Values.gitlab_app_name }}-etc"
+          claimName: "{{ .Values.gitlab.app_name }}-etc"
       - name: gitlab-ce-volume-2
         persistentVolumeClaim:
-          claimName: "{{ $.Values.gitlab_app_name }}-data"
+          claimName: "{{ .Values.gitlab.app_name }}-data"
 {{- if .Values.gitlab.cacert }}
       - name: gitlab-ca
         secret:
@@ -60,33 +56,51 @@ spec:
           items:
           - key: "ca-cert.crt"
             path: "ca-cert.crt"
-          secretName: gitlab-ca
+          secretName: "{{ .Values.gitlab.app_name }}-ca"
 {{- end }}
       containers:
       - name: gitlab-ce
-        image: gitlab-ce
+        image: repository.local/replaced-by-image-stream-trigger
         ports:
         - containerPort: 22
           protocol: TCP
         - containerPort: 80 
           protocol: TCP
         env:
+        - name: ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.gitlab.app_name }}-credentials"
+              key: root_password
+              optional: false
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.gitlab.app_name }}-credentials"
+              key: postgres_user
+              optional: false
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.gitlab.app_name }}-credentials"
+              key: postgres_password
+              optional: false
         - name: GITLAB_OMNIBUS_CONFIG
           value:
-            root_pass='{{ $root_pass }}';
-            external_url "https://{{ $.Values.gitlab_app_name }}.{{ include "tl500.app_domain" . }}";
+            root_pass="$(ROOT_PASSWORD)";
+            external_url "https://{{ .Values.gitlab.app_name }}.{{ include "tl500.app_domain" . }}";
             nginx['listen_port']=80;
             nginx['listen_https']=false;
             gitlab_rails['initial_root_password']=root_pass;
             gitlab_rails['gitlab_port']=80;
             letsencrypt['enable'] = false;
             postgresql['enable']=false;
-            gitlab_rails['db_host'] = '{{ $.Values.gitlab_app_name }}-postgresql';
-            gitlab_rails['db_password']='{{ $db_pass }}';
-            gitlab_rails['db_username']='{{ $db_user }}';
+            gitlab_rails['db_host'] = '{{ .Values.gitlab.app_name }}-postgresql';
+            gitlab_rails['db_password']="$(POSTGRESQL_PASSWORD)";
+            gitlab_rails['db_username']="$(POSTGRESQL_USER)";
             gitlab_rails['db_database']='{{ .Values.gitlab.db_name | default "gitlabhq_production" }}';
             redis['enable'] = false; 
-            gitlab_rails['redis_host']='{{ $.Values.gitlab_app_name }}-redis';
+            gitlab_rails['redis_host']='{{ .Values.gitlab.app_name }}-redis';
             unicorn['worker_processes'] = {{ .Values.gitlab.uni_workers | default 2 }}; 
             manage_accounts['enable'] = true;
             manage_storage_directories['manage_etc'] = false; 
@@ -141,15 +155,15 @@ spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       dnsPolicy: ClusterFirst
-      serviceAccount: "{{ $.Values.gitlab_app_name }}-user"
+      serviceAccount: "{{ .Values.gitlab.app_name }}-user"
 ---
 kind: DeploymentConfig
 apiVersion: apps.openshift.io/v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}-redis"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-redis"
+  namespace: "{{ .Values.gitlab.namespace }}"
   labels:
-    app: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ .Values.gitlab.app_name }}"
 spec:
   strategy:
     type: Recreate
@@ -164,17 +178,17 @@ spec:
       - gitlab-ce-redis
       from:
         kind: ImageStreamTag
-        name: "{{ $.Values.gitlab_app_name }}-redis:5.0.4"
+        name: "{{ .Values.gitlab.app_name }}-{{ .Values.gitlab.imagestreams.redis.name }}:{{ .Values.gitlab.imagestreams.redis.tag_name }}"
   replicas: 1
   test: false
   selector:
-    app: "{{ $.Values.gitlab_app_name }}"
-    deploymentconfig: "{{ $.Values.gitlab_app_name }}-redis"
+    app: "{{ .Values.gitlab.app_name }}"
+    deploymentconfig: "{{ .Values.gitlab.app_name }}-redis"
   template:
     metadata:
       labels:
-        app: "{{ $.Values.gitlab_app_name }}"
-        deploymentconfig: "{{ $.Values.gitlab_app_name }}-redis"
+        app: "{{ .Values.gitlab.app_name }}"
+        deploymentconfig: "{{ .Values.gitlab.app_name }}-redis"
     spec:
       {{- if .Values.runOnInfra }}
       nodeSelector:
@@ -190,10 +204,10 @@ spec:
       volumes:
       - name: gitlab-ce-volume-4
         persistentVolumeClaim:
-          claimName: "{{ $.Values.gitlab_app_name }}-redis-data"
+          claimName: "{{ .Values.gitlab.app_name }}-redis-data"
       containers:
       - name: gitlab-ce-redis
-        image: gitlab-ce-redis
+        image: repository.local/replaced-by-image-stream-trigger
         command:
         - "/bin/sh"
         - "-ec"
@@ -221,14 +235,14 @@ spec:
 kind: DeploymentConfig
 apiVersion: apps.openshift.io/v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}-postgresql"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-postgresql"
+  namespace: "{{ .Values.gitlab.namespace }}"
   labels:
-    app: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ .Values.gitlab.app_name }}"
 spec:
   strategy:
     type: Recreate
-    # this doesn't work when on an infra node as the node selector is inherited from the Deploy bt the tollerations are not...
+    # this doesn't work when on an infra node as the node selector is inherited from the Deploy but the tollerations are not...
     {{- if not .Values.runOnInfra }}
     recreateParams:
       post:
@@ -236,12 +250,11 @@ spec:
         execNewPod:
           containerName: gitlab-ce-postgresql
           command:
-          - "/usr/bin/scl"
-          - enable
-          - rh-postgresql96
-          - export PGPASSWORD='{{ $db_admin_pass }}'; psql -h '{{ $.Values.gitlab_app_name }}-postgresql'
-            -U postgres -d {{ .Values.gitlab.db_name | default "gitlabhq_production" }} -c 'CREATE EXTENSION IF NOT EXISTS
-            pg_trgm;'
+            - /bin/bash
+            - -c
+            - |
+              psql -h '{{ .Values.gitlab.app_name }}-postgresql' -U postgres -d {{ .Values.gitlab.db_name | default "gitlabhq_production" }} -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+              exit 0
           env:
           - name: HOME
             value: "/var/lib/pgsql"
@@ -249,6 +262,12 @@ spec:
             value: "/var/lib/pgsql/data/userdata"
           - name: CONTAINER_SCRIPTS_PATH
             value: "/usr/share/container-scripts/postgresql"
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.gitlab.app_name }}-credentials"
+                key: postgres_admin_password
+                optional: false
       {{- end }}
     resources: {}
   triggers:
@@ -260,18 +279,18 @@ spec:
       - gitlab-ce-postgresql
       from:
         kind: ImageStreamTag
-        name: postgresql:latest
+        name: "{{ .Values.gitlab.app_name }}-{{ .Values.gitlab.imagestreams.postgresql.name }}:{{ .Values.gitlab.imagestreams.postgresql.tag_name }}"
         namespace: {{ .Values.gitlab.namespace }}
   replicas: 1
   test: false
   selector:
-    app: "{{ $.Values.gitlab_app_name }}"
-    deploymentconfig: "{{ $.Values.gitlab_app_name }}-postgresql"
+    app: "{{ .Values.gitlab.app_name }}"
+    deploymentconfig: "{{ .Values.gitlab.app_name }}-postgresql"
   template:
     metadata:
       labels:
-        app: "{{ $.Values.gitlab_app_name }}"
-        deploymentconfig: "{{ $.Values.gitlab_app_name }}-postgresql"
+        app: "{{ .Values.gitlab.app_name }}"
+        deploymentconfig: "{{ .Values.gitlab.app_name }}-postgresql"
     spec:
       {{- if .Values.runOnInfra }}
       nodeSelector:
@@ -287,10 +306,10 @@ spec:
       volumes:
       - name: gitlab-ce-volume-3
         persistentVolumeClaim:
-          claimName: "{{ $.Values.gitlab_app_name }}-postgresql"
+          claimName: "{{ .Values.gitlab.app_name }}-postgresql"
       containers:
       - name: gitlab-ce-postgresql
-        image: gitlab-ce-postgresql
+        image: repository.local/replaced-by-image-stream-trigger
         ports:
         - containerPort: 5432
           protocol: TCP
@@ -311,13 +330,25 @@ spec:
             port: 5432
         env:
         - name: POSTGRESQL_USER
-          value: "{{ $db_user }}"
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.gitlab.app_name }}-credentials"
+              key: postgres_user
+              optional: false
         - name: POSTGRESQL_PASSWORD
-          value: "{{ $db_pass }}"
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.gitlab.app_name }}-credentials"
+              key: postgres_password
+              optional: false
         - name: POSTGRESQL_DATABASE
           value: "{{ .Values.gitlab.db_name | default "gitlabhq_production" }}"
         - name: POSTGRESQL_ADMIN_PASSWORD
-          value: "{{ $db_admin_pass }}"
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.gitlab.app_name }}-credentials"
+              key: postgres_admin_password
+              optional: false
         resources:
           limits:
             cpu: '1'
@@ -335,12 +366,11 @@ spec:
       dnsPolicy: ClusterFirst
 {{- if .Values.runOnInfra }}
 ---
-# job needs to be here otherwise the $db_admin_pass changes
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: configure-postgresql
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-configure-postgresql"
+  namespace: "{{ .Values.gitlab.namespace }}"
 spec:
   template:
     spec:
@@ -358,13 +388,14 @@ spec:
           - /bin/bash
           - -c
           - |
-            echo "Patching the postgresql, waiting a mo for it to be up ..."
-            sleep 30
-            /usr/bin/scl enable rh-postgresql96
-            export PGPASSWORD='{{ $db_admin_pass }}'
-            psql -h '{{ $.Values.gitlab_app_name }}-postgresql' -U postgres -d {{ .Values.gitlab.db_name | default "gitlabhq_production" }} -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+            echo "Waiting for postgresql to be ready..."
+            until pg_isready -h '{{ .Values.gitlab.app_name }}-postgresql' -p 5432
+            do
+              sleep 1
+            done
+            psql -h '{{ .Values.gitlab.app_name }}-postgresql' -U postgres -d {{ .Values.gitlab.db_name | default "gitlabhq_production" }} -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
             exit 0
-        image: "registry.redhat.io/rhscl/postgresql-96-rhel7:latest"
+        image: "{{ .Values.gitlab.imagestreams.postgresql.stream_uri }}"
         imagePullPolicy: IfNotPresent
         name: job
         env:
@@ -374,6 +405,12 @@ spec:
             value: "/var/lib/pgsql/data/userdata"
           - name: CONTAINER_SCRIPTS_PATH
             value: "/usr/share/container-scripts/postgresql"
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.gitlab.app_name }}-credentials"
+                key: postgres_admin_password
+                optional: false
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       terminationGracePeriodSeconds: 10

--- a/tooling/charts/tl500-base/templates/gitlab/imagestreams.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/imagestreams.yaml
@@ -4,10 +4,10 @@
 kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
-  name: "{{ $is.name }}"
+  name: "{{ $.Values.gitlab.app_name }}-{{ $is.name }}"
   namespace: {{ $.Values.gitlab.namespace }}
   labels:
-    app: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ $.Values.gitlab.app_name }}"
 spec:
   tags:
   - name: {{ $is.tag_name }}

--- a/tooling/charts/tl500-base/templates/gitlab/routes.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/routes.yaml
@@ -2,15 +2,15 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}"
+  namespace: "{{ .Values.gitlab.namespace }}"
   labels:
-    app: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ .Values.gitlab.app_name }}"
 spec:
-  host: {{ $.Values.gitlab_app_name }}.{{ include "tl500.app_domain" . }}
+  host: {{ .Values.gitlab.app_name }}.{{ include "tl500.app_domain" . }}
   to:
     kind: Service
-    name: "{{ $.Values.gitlab_app_name }}"
+    name: "{{ .Values.gitlab.app_name }}"
     weight: 100
   port:
     targetPort: 80-http

--- a/tooling/charts/tl500-base/templates/gitlab/secrets.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/secrets.yaml
@@ -7,8 +7,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gitlab-credentials
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-credentials"
+  namespace: "{{ .Values.gitlab.namespace }}"
   annotations:
     "helm.sh/resource-policy": "keep"
 type: Opaque
@@ -17,15 +17,16 @@ data:
   postgres_user: {{ $db_user | b64enc | quote }}
   postgres_password: {{ $db_pass | b64enc | quote }}
   postgres_admin_password: {{ $db_admin_pass | b64enc | quote }}
+immutable: true
 {{- if .Values.gitlab.cacert }}
 ---
 apiVersion: v1
-data:
-  ca-cert.crt: "{{ .Values.gitlab.cacert }}"
 kind: Secret
 metadata:
-  name: gitlab-ca
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-ca"
+  namespace: "{{ .Values.gitlab.namespace }}"
 type: Opaque
+data:
+  ca-cert.crt: "{{ .Values.gitlab.cacert }}"
 {{- end }}
 {{- end }}

--- a/tooling/charts/tl500-base/templates/gitlab/secrets.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/secrets.yaml
@@ -1,4 +1,24 @@
+{{- if .Values.gitlab -}}
+{{ $root_pass := include "gitlab.root_password" . }}
+{{ $db_user := include "gitlab.postgres.user" . }}
+{{ $db_pass := include "gitlab.postgres.password" . }}
+{{ $db_admin_pass := include "gitlab.postgres.admin_password" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-credentials
+  namespace: "{{ $.Values.gitlab.namespace }}"
+  annotations:
+    "helm.sh/resource-policy": "keep"
+type: Opaque
+data:
+  root_password: {{ $root_pass | b64enc | quote }}
+  postgres_user: {{ $db_user | b64enc | quote }}
+  postgres_password: {{ $db_pass | b64enc | quote }}
+  postgres_admin_password: {{ $db_admin_pass | b64enc | quote }}
 {{- if .Values.gitlab.cacert }}
+---
 apiVersion: v1
 data:
   ca-cert.crt: "{{ .Values.gitlab.cacert }}"
@@ -7,4 +27,5 @@ metadata:
   name: gitlab-ca
   namespace: "{{ $.Values.gitlab.namespace }}"
 type: Opaque
+{{- end }}
 {{- end }}

--- a/tooling/charts/tl500-base/templates/gitlab/serviceaccounts.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/serviceaccounts.yaml
@@ -3,6 +3,6 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}-user"
+  name: "{{ .Values.gitlab.app_name }}-user"
   namespace: "{{ .Values.gitlab.namespace }}"
 {{- end -}}

--- a/tooling/charts/tl500-base/templates/gitlab/services.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/services.yaml
@@ -3,10 +3,10 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}"
+  namespace: "{{ .Values.gitlab.namespace }}"
   labels:
-    app: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ .Values.gitlab.app_name }}"
 spec:
   ports:
   - name: 22-ssh
@@ -18,18 +18,18 @@ spec:
     port: 80
     targetPort: 80
   selector:
-    app: "{{ $.Values.gitlab_app_name }}"
-    deploymentconfig: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ .Values.gitlab.app_name }}"
+    deploymentconfig: "{{ .Values.gitlab.app_name }}"
   type: ClusterIP
   sessionAffinity: None
 ---
 kind: Service
 apiVersion: v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}-redis"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-redis"
+  namespace: "{{ .Values.gitlab.namespace }}"
   labels:
-    app: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ .Values.gitlab.app_name }}"
 spec:
   ports:
   - name: 6379-redis
@@ -37,18 +37,18 @@ spec:
     port: 6379
     targetPort: 6379
   selector:
-    app: "{{ $.Values.gitlab_app_name }}"
-    deploymentconfig: "{{ $.Values.gitlab_app_name }}-redis"
+    app: "{{ .Values.gitlab.app_name }}"
+    deploymentconfig: "{{ .Values.gitlab.app_name }}-redis"
   type: ClusterIP
   sessionAffinity: None
 ---
 kind: Service
 apiVersion: v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}-postgresql"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-postgresql"
+  namespace: "{{ .Values.gitlab.namespace }}"
   labels:
-    app: "{{ $.Values.gitlab_app_name }}"
+    app: "{{ .Values.gitlab.app_name }}"
 spec:
   ports:
   - name: 5432-postgresql
@@ -56,8 +56,8 @@ spec:
     port: 5432
     targetPort: 5432
   selector:
-    app: "{{ $.Values.gitlab_app_name }}"
-    deploymentconfig: "{{ $.Values.gitlab_app_name }}-postgresql"
+    app: "{{ .Values.gitlab.app_name }}"
+    deploymentconfig: "{{ .Values.gitlab.app_name }}-postgresql"
   type: ClusterIP
   sessionAffinity: None
 {{- end }}

--- a/tooling/charts/tl500-base/templates/gitlab/volumeclaims.yaml
+++ b/tooling/charts/tl500-base/templates/gitlab/volumeclaims.yaml
@@ -3,8 +3,8 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}-redis-data"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-redis-data"
+  namespace: "{{ .Values.gitlab.namespace }}"
 spec:
   accessModes:
   - ReadWriteOnce
@@ -15,8 +15,8 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}-etc"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-etc"
+  namespace: "{{ .Values.gitlab.namespace }}"
 spec:
   accessModes:
   - ReadWriteOnce
@@ -27,8 +27,8 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}-data"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-data"
+  namespace: "{{ .Values.gitlab.namespace }}"
 spec:
   accessModes:
   - ReadWriteOnce
@@ -39,12 +39,12 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ $.Values.gitlab_app_name }}-postgresql"
-  namespace: "{{ $.Values.gitlab.namespace }}"
+  name: "{{ .Values.gitlab.app_name }}-postgresql"
+  namespace: "{{ .Values.gitlab.namespace }}"
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: "{{ $.Values.gitlab.postgres_size | default "2Gi" }}"
+      storage: "{{ .Values.gitlab.postgres_size | default "2Gi" }}"
 {{- end }}

--- a/tooling/charts/tl500-base/values.yaml
+++ b/tooling/charts/tl500-base/values.yaml
@@ -1,5 +1,4 @@
 # Default values for tl500
-gitlab_app_name: "gitlab-ce"
 
 # Create a helper to create a prefix if one isn't provided? Would help if we moved to shared clusters
 prefix: ""
@@ -104,6 +103,7 @@ minio:
   namespace: tl500-minio
 
 gitlab:
+  app_name: "gitlab-ce"
   namespace: tl500-gitlab
   credentials:
     root_password: ''
@@ -111,13 +111,16 @@ gitlab:
     postgres_password: ''
     postgres_admin_password: ''
   imagestreams:
-    - name: "gitlab-ce"
-      tag_name: "gitlab-12.8.7"
+    gitlab:
+      name: "gitlab-ce"
+      tag_name: "latest"
       stream_uri: "gitlab/gitlab-ce:12.8.7-ce.0"
-    - name: "gitlab-ce-redis"
-      tag_name: "5.0.4"
+    redis:
+      name: "redis"
+      tag_name: "latest"
       stream_uri: "redis:5.0.4-alpine"
-    - name: "postgresql"
+    postgresql:
+      name: "postgresql"
       tag_name: "latest"
       stream_uri: "registry.redhat.io/rhscl/postgresql-96-rhel7"
 # a body of CA certificate that Gitlab should be using goes in here. Body needs to be Base64!

--- a/tooling/charts/tl500-base/values.yaml
+++ b/tooling/charts/tl500-base/values.yaml
@@ -105,7 +105,11 @@ minio:
 
 gitlab:
   namespace: tl500-gitlab
-  root_password: 7aydhn160bOrrsGEbnd172rE
+  credentials:
+    root_password: ''
+    postgres_user: ''
+    postgres_password: ''
+    postgres_admin_password: ''
   imagestreams:
     - name: "gitlab-ce"
       tag_name: "gitlab-12.8.7"


### PR DESCRIPTION
Store Gitlab credentials in a secret to address issue #69 

The user can set the desired credentials during installation, otherwise the credentials will be generated. During upgrade, the credentials are retrieved from the secret.

Note that this fix does not attempt to address the issue when the user tries to reset the Gitlab credentials during an upgrade.