### PR TITLE
Added a new job to disable the affinity assistant in Openshift pipelines

### DIFF
--- a/tooling/charts/tl500-base/templates/pipelines/config-pipelines.yaml
+++ b/tooling/charts/tl500-base/templates/pipelines/config-pipelines.yaml
@@ -1,0 +1,25 @@
+{{- if not .Values.ignoreHelmHooks }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: config-pipelines
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccount: default
+      serviceAccountName: default
+      containers:
+      - name: job
+        image: "quay.io/openshift/origin-cli:latest"
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/bash
+          - -c
+          - | # Disable affinity assitant: https://access.redhat.com/solutions/7128120
+            oc patch tektonconfig.operator.tekton.dev/config --patch '{"spec":{"pipeline":{"coschedule":"disabled"}}}' --type=merge
+{{- end }}

--- a/tooling/charts/tl500-base/templates/pipelines/rbac.yaml
+++ b/tooling/charts/tl500-base/templates/pipelines/rbac.yaml
@@ -1,0 +1,37 @@
+{{- if not .Values.ignoreHelmHooks }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: config-pipelines
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - operator.tekton.dev
+  resources:
+  - tektonconfigs
+  verbs:
+  - get
+  - list
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: config-pipelines
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: config-pipelines
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.namespace | default "tl500" }}
+{{- end }}


### PR DESCRIPTION
Currently with the default pipelines installation we retrieve the following error:

`[User error] more than one PersistentVolumeClaim is bound`

This is fixed by updating the TektonConfig as seen here:
https://access.redhat.com/solutions/7128120

Also documented by Roman Marting in the following [section](https://github.com/rh-open-innovation-labs/tech-exercise/blob/95d6dc41e8ffa678222063b0987fc204fdc0d541/docs/2-attack-of-the-pipelines/666-here-be-dragons.md#tekton-affinity-assistant-configuration)


