### PR TITLE
Update GitLab chart version to 9.7.0

### DIFF
--- a/tooling/charts/tl500-course-content/templates/gitlab/gitlab-tl500.yaml
+++ b/tooling/charts/tl500-course-content/templates/gitlab/gitlab-tl500.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: gitlab-system
 spec:
   chart:
-    version: "9.6.2" # https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/blob/<OPERATOR_VERSION>/CHART_VERSIONS
+    version: "9.7.0" # https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/blob/<OPERATOR_VERSION>/CHART_VERSIONS
     values:
       nginx-ingress:
         enabled: false


### PR DESCRIPTION
The https://github.com/rht-labs/enablement-framework/pull/187 fixes the deployment of the GitLab instance, but for some reason, the webservice does not come up. Upgrading to 9.7.0 which is the latest version fixes all the issues. The GitLab instance is now fully up and running.