### PR TITLE
Extract and bump gitlab version

### DIFF
--- a/tooling/charts/tl500-course-content/templates/gitlab/gitlab-tl500.yaml
+++ b/tooling/charts/tl500-course-content/templates/gitlab/gitlab-tl500.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: gitlab-system
 spec:
   chart:
-    version: "9.6.2" # https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/blob/<OPERATOR_VERSION>/CHART_VERSIONS
+    version: {{ .Values.gitlab.chart_version | default 9.9.3 }} # https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/blob/<OPERATOR_VERSION>/CHART_VERSIONS
     values:
       nginx-ingress:
         enabled: false

--- a/tooling/charts/tl500-course-content/values.yaml
+++ b/tooling/charts/tl500-course-content/values.yaml
@@ -34,6 +34,9 @@ crw:
     CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT: '-1'
     CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY: Always
 
+gitlab:
+  chart_version: 9.9.3. # This value likely needs updating regularly, whenever the operator version changes
+
 # Tech-exercises deployment to engagement environment
 # Deployment done only if `docs:` is uncommented 
 #docs:


### PR DESCRIPTION
The gitlab version will need to be bumped pretty regularly. I've extracted it to a var to make it easier to overwrite

Note that the Gitlab chart version changes regularly and will not deploy if not matching the gitlab operator acceptable values (found on the [operator releases page](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/releases)). It is possible to override the default value to an acceptable one by adding `--set gitlab.chart_version=<VERSION>` to the `helm install` or `helm upgrade` commands for `tl500-course-content`.

This will still mean that, if outdated, the tl500-course-content chart will fail in the lab deployment. But potentially the automation for that could be updated to collect the acceptable version?